### PR TITLE
Drop active-support dependency

### DIFF
--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   # This should be kept in sync with the json-schema version of govuk-content-schemas.
   spec.add_dependency "json-schema", "2.5.0"
-  spec.add_dependency "activesupport"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -1,5 +1,6 @@
 require "govuk_schemas/version"
 require "govuk_schemas/schema"
+require "govuk_schemas/utils"
 require "govuk_schemas/random_example"
 
 module GovukSchemas

--- a/lib/govuk_schemas/random.rb
+++ b/lib/govuk_schemas/random.rb
@@ -1,5 +1,3 @@
-require "active_support/core_ext/string"
-
 module GovukSchemas
   module Random
     class << self

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -1,6 +1,5 @@
 require "govuk_schemas/random"
 require "govuk_schemas/random_item_generator"
-require "active_support/core_ext/hash"
 require "json-schema"
 require "json"
 
@@ -32,7 +31,7 @@ module GovukSchemas
 
     # TODO: add docs
     def merge_and_validate(hash)
-      item = payload.merge(hash.stringify_keys)
+      item = payload.merge(Utils.stringify_keys(hash))
       errors = validation_errors_for(item)
 
       if errors.any?

--- a/lib/govuk_schemas/schema.rb
+++ b/lib/govuk_schemas/schema.rb
@@ -17,5 +17,10 @@ module GovukSchemas
         hash
       end
     end
+
+    # Return a random schema
+    def self.random_schema
+      all.values.sample
+    end
   end
 end

--- a/lib/govuk_schemas/utils.rb
+++ b/lib/govuk_schemas/utils.rb
@@ -1,0 +1,9 @@
+module Utils
+  def self.stringify_keys(hash)
+    new_hash = {}
+    hash.each do |k, v|
+      new_hash[k.to_s] = v
+    end
+    new_hash
+  end
+end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -17,4 +17,22 @@ RSpec.describe GovukSchemas::RandomExample do
       end
     end
   end
+
+  describe "#merge_and_validate" do
+    it "returns the merged payload" do
+      schema = GovukSchemas::Schema.random_schema
+
+      item = GovukSchemas::RandomExample.new(schema: schema).merge_and_validate(base_path: "/some-base-path")
+
+      expect(item["base_path"]).to eql("/some-base-path")
+    end
+
+    it "raises if the resulting content item won't be valid" do
+      schema = GovukSchemas::Schema.random_schema
+
+      expect {
+        GovukSchemas::RandomExample.new(schema: schema).merge_and_validate(base_path: nil)
+      }.to raise_error(GovukSchemas::InvalidContentGenerated)
+    end
+  end
 end


### PR DESCRIPTION
active-support is already a dependency of most GOV.UK projects, and I'd like to avoid a situation where we depend on a newer/older version in this gem, causing dependency conflicts. It's best practice to avoid any unnecessary dependencies in gems.
