### PR TITLE
Allow users to specify schema_type for random schema

### DIFF
--- a/lib/govuk_schemas/schema.rb
+++ b/lib/govuk_schemas/schema.rb
@@ -11,16 +11,17 @@ module GovukSchemas
     end
 
     # Return all schemas in a hash, keyed by schema name
-    def self.all
-      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/**/*.json").reduce({}) do |hash, file_path|
+    def self.all(schema_type: '*')
+      schema_type = "publisher_v2" if schema_type == "publisher"
+      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/*/#{schema_type}/*.json").reduce({}) do |hash, file_path|
         hash[file_path] = JSON.parse(File.read(file_path))
         hash
       end
     end
 
     # Return a random schema
-    def self.random_schema
-      all.values.sample
+    def self.random_schema(schema_type:)
+      all(schema_type: schema_type).values.sample
     end
   end
 end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukSchemas::RandomExample do
 
   describe "#merge_and_validate" do
     it "returns the merged payload" do
-      schema = GovukSchemas::Schema.random_schema
+      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
 
       item = GovukSchemas::RandomExample.new(schema: schema).merge_and_validate(base_path: "/some-base-path")
 
@@ -28,7 +28,7 @@ RSpec.describe GovukSchemas::RandomExample do
     end
 
     it "raises if the resulting content item won't be valid" do
-      schema = GovukSchemas::Schema.random_schema
+      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
 
       expect {
         GovukSchemas::RandomExample.new(schema: schema).merge_and_validate(base_path: nil)


### PR DESCRIPTION
This is useful if we want to use a random frontend, notification or publisher schema.