### PR TITLE
Also test specialist documents

### DIFF
--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -1,18 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe GovukSchemas::RandomExample do
-  ITERATIONS = ENV['ITERATIONS'] || 1
-
   describe '#payload' do
     GovukSchemas::Schema.all.each do |file_path, schema|
-      # Specialist documents have complex schemas that are hard to generate content for.
-      skipped = file_path.match("specialist_document")
-
-      it "generates valid content for schema #{file_path}", skip: skipped do
-        ITERATIONS.times do
-          # This will raise an informative error if an invalid schema is generated.
-          GovukSchemas::RandomExample.new(schema: schema).payload
-        end
+      it "generates valid content for schema #{file_path}" do
+        # This will raise an informative error if an invalid schema is generated.
+        GovukSchemas::RandomExample.new(schema: schema).payload
       end
     end
   end


### PR DESCRIPTION
https://github.com/alphagov/govuk-content-schemas/pull/397 makes testing with specialist documents possible, because this gem won't generate invalid data for `anyOf` schemas.

https://github.com/alphagov/govuk-content-schemas/pull/397 needs merging first.