### PR TITLE
Be less strict about json-schema version

### DIFF
--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # This should be kept in sync with the json-schema version of govuk-content-schemas.
-  spec.add_dependency "json-schema", "2.5.0"
+  spec.add_dependency "json-schema", "~> 2.5.0"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"


### PR DESCRIPTION
Publishing-api is currently on 2.5.2, so won't work with this version of the gem. Pinning on 2.5.X is better anyway since we trust json-schema to follow semantic versioning.
