### PR TITLE
Support use with only dist directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.0.0
+
 * Change GOVUK\_CONTENT\_SCHEMAS\_PATH to refer to the dist directory
 * Add regex for lowercase-underscore strings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Change GOVUK\_CONTENT\_SCHEMAS\_PATH to refer to the dist directory
 * Add regex for lowercase-underscore strings
 
 # 1.0.0

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -51,7 +51,7 @@ git clone git@github.com:alphagov/govuk-content-schemas.git /tmp/govuk-content-s
  cd /tmp/govuk-content-schemas
  git checkout ${SCHEMA_GIT_COMMIT:-"master"}
 )
-export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
+export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas/dist
 
 # Bundle and run tests against multiple ruby versions
 for version in 2.3.1; do

--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -5,7 +5,7 @@ require "govuk_schemas/random_example"
 
 module GovukSchemas
   # @private
-  CONTENT_SCHEMA_DIR = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../govuk-content-schemas"
+  CONTENT_SCHEMA_DIR = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../govuk-content-schemas/dist"
 
   # @private
   class InvalidContentGenerated < Exception

--- a/lib/govuk_schemas/schema.rb
+++ b/lib/govuk_schemas/schema.rb
@@ -6,7 +6,7 @@ module GovukSchemas
     # @param schema_type [String] The type: frontend, publisher, notification or links
     def self.find(schema_name, schema_type:)
       schema_type = "publisher_v2" if schema_type == "publisher"
-      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/#{schema_name}/#{schema_type}/schema.json"
+      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/#{schema_type}/schema.json"
       JSON.parse(File.read(file_path))
     end
 
@@ -15,7 +15,7 @@ module GovukSchemas
     # @param schema_type [String] The type: frontend, publisher, notification or links
     def self.all(schema_type: '*')
       schema_type = "publisher_v2" if schema_type == "publisher"
-      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/*/#{schema_type}/*.json").reduce({}) do |hash, file_path|
+      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/*/#{schema_type}/*.json").reduce({}) do |hash, file_path|
         hash[file_path] = JSON.parse(File.read(file_path))
         hash
       end

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "1.0.0".freeze
+  VERSION = "2.0.0".freeze
 end


### PR DESCRIPTION
The contents of the dist directory is what is needed, so change the
GOVUK_CONTENT_SCHEMAS_PATH to refer to that instead. One of the
advantages of this is that applications using this library can use it in
development, and easily in production, where only the dist directory is
available.

This will require anything using this library to load schemas to change
the configuration of the environmental variable.

Because of this, bump major version to 2.0.0 