### PR TITLE
Change Schema .find API

### DIFF
--- a/lib/govuk_schemas/schema.rb
+++ b/lib/govuk_schemas/schema.rb
@@ -2,12 +2,33 @@ module GovukSchemas
   class Schema
     # Find a schema by name
     #
-    # @param schema_name [String] Name of the schema/format
-    # @param schema_type [String] The type: frontend, publisher, notification or links
-    def self.find(schema_name, schema_type:)
-      schema_type = "publisher_v2" if schema_type == "publisher"
-      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/#{schema_name}/#{schema_type}/schema.json"
+    # @param schema [Hash] Type => Name of the schema/format:
+    # Accepted arguments:
+    # { links_schema: schema_name }
+    # { frontend_schema: schema_name }
+    # { publisher_schema: schema_name }
+    # { notification_schema: schema_name }
+    def self.find(schema)
+      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/#{type_location(schema)}"
       JSON.parse(File.read(file_path))
+    end
+
+    # Find a schema type location by name
+    #
+    # @param schema [Hash] Type => Name of the schema/format:
+    # Accepted arguments:
+    # { links_schema: schema_name }
+    # { frontend_schema: schema_name }
+    # { publisher_schema: schema_name }
+    # { notification_schema: schema_name }
+    def self.type_location(schema)
+      type, schema_name = schema.to_a.flatten
+      {
+        links_schema: "#{schema_name}/publisher_v2/links.json",
+        frontend_schema: "#{schema_name}/frontend/schema.json",
+        publisher_schema: "#{schema_name}/publisher_v2/schema.json",
+        notification_schema: "#{schema_name}/notification/schema.json",
+      }[type]
     end
 
     # Return all schemas in a hash, keyed by schema name

--- a/spec/lib/schema_spec.rb
+++ b/spec/lib/schema_spec.rb
@@ -2,18 +2,53 @@ require 'spec_helper'
 
 RSpec.describe GovukSchemas::Schema do
   describe '.find' do
-    it 'returns a schema by name' do
-      schema = GovukSchemas::Schema.find("detailed_guide", schema_type: "frontend")
+    subject { GovukSchemas::Schema.find(type) }
 
-      expect(schema).to be_a(Hash)
+    context "frontend_schema" do
+      let(:type) { { frontend_schema: "detailed_guide" } }
+      it 'returns a frontend schema by name' do
+        expect(subject).to be_a(Hash)
+      end
+    end
+  end
+
+  describe '.type_location' do
+    subject { GovukSchemas::Schema.type_location(schema) }
+
+    context "frontend_schema" do
+      let(:schema) { { frontend_schema: "detailed_guide" } }
+      it 'returns the location' do
+        expect(subject).to eq('detailed_guide/frontend/schema.json')
+      end
+    end
+
+    context "links_schema" do
+      let(:schema) { { links_schema: "detailed_guide" } }
+      it 'returns the location' do
+        expect(subject).to eq('detailed_guide/publisher_v2/links.json')
+      end
+    end
+
+    context "publisher_schema" do
+      let(:schema) { { publisher_schema: "detailed_guide" } }
+      it 'returns the location' do
+        expect(subject).to eq('detailed_guide/publisher_v2/schema.json')
+      end
+    end
+
+    context "notification_schema" do
+      let(:schema) { { notification_schema: "detailed_guide" } }
+      it 'returns the location' do
+        expect(subject).to eq('detailed_guide/notification/schema.json')
+      end
     end
   end
 
   describe '.all' do
-    it 'returns all GOV.UK schemas' do
-      schemas = GovukSchemas::Schema.all
+    subject { GovukSchemas::Schema.all }
 
-      expect(schemas).to be_a(Hash)
+    it 'returns all GOV.UK schemas' do
+      expect(subject).to be_a(Hash)
     end
   end
 end


### PR DESCRIPTION
You can now be more explicit in what schema you are finding:

GovukSchemas::Schema.find(links_schema: 'detailded_guide')
GovukSchemas::Schema.find(frontend_schema: 'detailded_guide')
GovukSchemas::Schema.find(publisher_schema: 'detailded_guide')
GovukSchemas::Schema.find(notification_schema: 'detailded_guide')