### PR TITLE
Fix `RandomExample.for_schema` method

### DIFF
--- a/docs/GovukSchemas.html
+++ b/docs/GovukSchemas.html
@@ -111,7 +111,7 @@
 </div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:37 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/docs/GovukSchemas/RandomExample.html
+++ b/docs/GovukSchemas/RandomExample.html
@@ -117,7 +117,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#for_schema-class_method" title="for_schema (class method)">+ (GovukSchemas::RandomExample) <strong>for_schema</strong>(schema_name, schema_type:) </a>
+      <a href="#for_schema-class_method" title="for_schema (class method)">+ (GovukSchemas::RandomExample) <strong>for_schema</strong>(schema_key_value) </a>
     
 
     
@@ -306,7 +306,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="for_schema-class_method">
   
-    + (<tt><span class='object_link'><a href="" title="GovukSchemas::RandomExample (class)">GovukSchemas::RandomExample</a></span></tt>) <strong>for_schema</strong>(schema_name, schema_type:) 
+    + (<tt><span class='object_link'><a href="" title="GovukSchemas::RandomExample (class)">GovukSchemas::RandomExample</a></span></tt>) <strong>for_schema</strong>(schema_key_value) 
   
 
   
@@ -319,7 +319,7 @@
 
 <p>For example:</p>
 
-<pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_generator'>generator</span> <span class='op'>=</span> <span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>RandomExample</span><span class='period'>.</span><span class='id identifier rubyid_for_schema'>for_schema</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>detailed_guide</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='label'>schema_type:</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>frontend</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+<pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_generator'>generator</span> <span class='op'>=</span> <span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>RandomExample</span><span class='period'>.</span><span class='id identifier rubyid_for_schema'>for_schema</span><span class='lparen'>(</span><span class='label'>frontend_schema:</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>detailed_guide</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
 <span class='id identifier rubyid_generator'>generator</span><span class='period'>.</span><span class='id identifier rubyid_payload'>payload</span>
 <span class='comment'># =&gt; {&quot;base_path&quot;=&gt;&quot;/e42dd28e&quot;, &quot;title&quot;=&gt;&quot;dolor est...&quot;, &quot;publishing_app&quot;=&gt;&quot;elit&quot;...}
 </span></code></pre>
@@ -328,7 +328,22 @@
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>schema_key_value</span>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
 <p class="tag_title">Returns:</p>
 <ul class="return">
   
@@ -349,16 +364,16 @@
       <pre class="lines">
 
 
-31
 32
 33
-34</pre>
+34
+35</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/random_example.rb', line 31</span>
+      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/random_example.rb', line 32</span>
 
-<span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_for_schema'>for_schema</span><span class='lparen'>(</span><span class='id identifier rubyid_schema_name'>schema_name</span><span class='comma'>,</span> <span class='label'>schema_type:</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_schema'>schema</span> <span class='op'>=</span> <span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>Schema</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_schema_name'>schema_name</span><span class='comma'>,</span> <span class='label'>schema_type:</span> <span class='id identifier rubyid_schema_type'>schema_type</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_for_schema'>for_schema</span><span class='lparen'>(</span><span class='id identifier rubyid_schema_key_value'>schema_key_value</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_schema'>schema</span> <span class='op'>=</span> <span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>Schema</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_schema_key_value'>schema_key_value</span><span class='rparen'>)</span>
   <span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>RandomExample</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='label'>schema:</span> <span class='id identifier rubyid_schema'>schema</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -457,7 +472,6 @@ isn&#39;t valid against the schema an error will be raised.</p>
       <pre class="lines">
 
 
-67
 68
 69
 70
@@ -466,17 +480,18 @@ isn&#39;t valid against the schema an error will be raised.</p>
 73
 74
 75
-76</pre>
+76
+77</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/random_example.rb', line 67</span>
+      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/random_example.rb', line 68</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_merge_and_validate'>merge_and_validate</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_item'>item</span> <span class='op'>=</span> <span class='id identifier rubyid_payload'>payload</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='const'>Utils</span><span class='period'>.</span><span class='id identifier rubyid_stringify_keys'>stringify_keys</span><span class='lparen'>(</span><span class='id identifier rubyid_hash'>hash</span><span class='rparen'>)</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_errors'>errors</span> <span class='op'>=</span> <span class='id identifier rubyid_validation_errors_for'>validation_errors_for</span><span class='lparen'>(</span><span class='id identifier rubyid_item'>item</span><span class='rparen'>)</span>
 
   <span class='kw'>if</span> <span class='id identifier rubyid_errors'>errors</span><span class='period'>.</span><span class='id identifier rubyid_any?'>any?</span>
-    <span class='id identifier rubyid_raise'>raise</span> <span class='const'>InvalidContentGenerated</span><span class='comma'>,</span> <span class='id identifier rubyid_error_message_custom'>error_message_custom</span><span class='lparen'>(</span><span class='id identifier rubyid_item'>item</span><span class='comma'>,</span> <span class='id identifier rubyid_errors'>errors</span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_raise'>raise</span> <span class='const'>InvalidContentGenerated</span><span class='comma'>,</span> <span class='id identifier rubyid_error_message_custom'>error_message_custom</span><span class='lparen'>(</span><span class='id identifier rubyid_item'>item</span><span class='comma'>,</span> <span class='id identifier rubyid_hash'>hash</span><span class='comma'>,</span> <span class='id identifier rubyid_errors'>errors</span><span class='rparen'>)</span>
   <span class='kw'>end</span>
 
   <span class='id identifier rubyid_item'>item</span>
@@ -536,7 +551,6 @@ isn&#39;t valid against the schema an error will be raised.</p>
       <pre class="lines">
 
 
-44
 45
 46
 47
@@ -545,10 +559,11 @@ isn&#39;t valid against the schema an error will be raised.</p>
 50
 51
 52
-53</pre>
+53
+54</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/random_example.rb', line 44</span>
+      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/random_example.rb', line 45</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_payload'>payload</span>
   <span class='id identifier rubyid_item'>item</span> <span class='op'>=</span> <span class='ivar'>@random_generator</span><span class='period'>.</span><span class='id identifier rubyid_payload'>payload</span>
@@ -570,7 +585,7 @@ isn&#39;t valid against the schema an error will be raised.</p>
 </div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:38 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/docs/GovukSchemas/Schema.html
+++ b/docs/GovukSchemas/Schema.html
@@ -117,7 +117,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#all-class_method" title="all (class method)">+ (Object) <strong>all</strong>(schema_type: &#39;*&#39;) </a>
+      <a href="#all-class_method" title="all (class method)">+ (Array&lt;Hash&gt;) <strong>all</strong>(schema_type: &#39;*&#39;) </a>
     
 
     
@@ -141,7 +141,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#find-class_method" title="find (class method)">+ (Object) <strong>find</strong>(schema_name, schema_type:) </a>
+      <a href="#find-class_method" title="find (class method)">+ (Hash) <strong>find</strong>(schema) </a>
     
 
     
@@ -165,7 +165,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#random_schema-class_method" title="random_schema (class method)">+ (Object) <strong>random_schema</strong>(schema_type:) </a>
+      <a href="#random_schema-class_method" title="random_schema (class method)">+ (Hash) <strong>random_schema</strong>(schema_type:) </a>
     
 
     
@@ -198,7 +198,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="all-class_method">
   
-    + (<tt>Object</tt>) <strong>all</strong>(schema_type: &#39;*&#39;) 
+    + (<tt>Array&lt;Hash&gt;</tt>) <strong>all</strong>(schema_type: &#39;*&#39;) 
   
 
   
@@ -234,6 +234,24 @@
   
 </ul>
 
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array&lt;Hash&gt;</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>List of JSON schemas as hashes</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div><table class="source_code">
   <tr>
@@ -241,16 +259,16 @@
       <pre class="lines">
 
 
-16
-17
-18
-19
-20
-21
-22</pre>
+22
+23
+24
+25
+26
+27
+28</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/schema.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/schema.rb', line 22</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_all'>all</span><span class='lparen'>(</span><span class='label'>schema_type:</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>*</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
   <span class='id identifier rubyid_schema_type'>schema_type</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>publisher_v2</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>if</span> <span class='id identifier rubyid_schema_type'>schema_type</span> <span class='op'>==</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>publisher</span><span class='tstring_end'>&quot;</span></span>
@@ -267,7 +285,7 @@
       <div class="method_details ">
   <h3 class="signature " id="find-class_method">
   
-    + (<tt>Object</tt>) <strong>find</strong>(schema_name, schema_type:) 
+    + (<tt>Hash</tt>) <strong>find</strong>(schema) 
   
 
   
@@ -282,43 +300,57 @@
   </div>
 </div>
 <div class="tags">
-  <p class="tag_title">Parameters:</p>
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>
+<span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>Schema</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='label'>links_schema:</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>detailed_guide</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+<span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>Schema</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='label'>frontend_schema:</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>detailed_guide</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+<span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>Schema</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='label'>publisher_schema:</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>detailed_guide</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+<span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>Schema</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='label'>notification_schema:</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>detailed_guide</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span></code></pre>
+    
+  </div>
+<p class="tag_title">Parameters:</p>
 <ul class="param">
   
     <li>
       
-        <span class='name'>schema_name</span>
+        <span class='name'>schema</span>
       
       
-        <span class='type'>(<tt>String</tt>)</span>
-      
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>Name of the schema/format</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>schema_type</span>
-      
-      
-        <span class='type'>(<tt>String</tt>)</span>
+        <span class='type'>(<tt>Hash</tt>)</span>
       
       
       
         &mdash;
         <div class='inline'>
-<p>The type: frontend, publisher, notification or links</p>
+<p>Type =&gt; Name of the schema/format:</p>
 </div>
       
     </li>
   
 </ul>
 
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>the JSON schema as a hash</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div><table class="source_code">
   <tr>
@@ -326,18 +358,16 @@
       <pre class="lines">
 
 
-7
-8
-9
-10
-11</pre>
+13
+14
+15
+16</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/schema.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/schema.rb', line 13</span>
 
-<span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_schema_name'>schema_name</span><span class='comma'>,</span> <span class='label'>schema_type:</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_schema_type'>schema_type</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>publisher_v2</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>if</span> <span class='id identifier rubyid_schema_type'>schema_type</span> <span class='op'>==</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>publisher</span><span class='tstring_end'>&quot;</span></span>
-  <span class='id identifier rubyid_file_path'>file_path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>CONTENT_SCHEMA_DIR</span><span class='embexpr_end'>}</span><span class='tstring_content'>/dist/formats/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_schema_name'>schema_name</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_schema_type'>schema_type</span><span class='embexpr_end'>}</span><span class='tstring_content'>/schema.json</span><span class='tstring_end'>&quot;</span></span>
+<span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_schema'>schema</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_file_path'>file_path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='const'>GovukSchemas</span><span class='op'>::</span><span class='const'>CONTENT_SCHEMA_DIR</span><span class='embexpr_end'>}</span><span class='tstring_content'>/dist/formats/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_location_for_schema_name'>location_for_schema_name</span><span class='lparen'>(</span><span class='id identifier rubyid_schema'>schema</span><span class='rparen'>)</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
   <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_read'>read</span><span class='lparen'>(</span><span class='id identifier rubyid_file_path'>file_path</span><span class='rparen'>)</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -348,7 +378,7 @@
       <div class="method_details ">
   <h3 class="signature " id="random_schema-class_method">
   
-    + (<tt>Object</tt>) <strong>random_schema</strong>(schema_type:) 
+    + (<tt>Hash</tt>) <strong>random_schema</strong>(schema_type:) 
   
 
   
@@ -384,6 +414,24 @@
   
 </ul>
 
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>a JSON schema as a hash</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div><table class="source_code">
   <tr>
@@ -391,12 +439,12 @@
       <pre class="lines">
 
 
-27
-28
-29</pre>
+34
+35
+36</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/schema.rb', line 27</span>
+      <pre class="code"><span class="info file"># File 'lib/govuk_schemas/schema.rb', line 34</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_random_schema'>random_schema</span><span class='lparen'>(</span><span class='label'>schema_type:</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_all'>all</span><span class='lparen'>(</span><span class='label'>schema_type:</span> <span class='id identifier rubyid_schema_type'>schema_type</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='period'>.</span><span class='id identifier rubyid_sample'>sample</span>
@@ -411,7 +459,7 @@
 </div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:37 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -131,7 +131,7 @@
 </div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:37 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -74,6 +74,20 @@ href="https://github.com/alphagov/govuk-content-schemas">govuk-content-schemas</
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_gem'>gem</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>govuk_schemas</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>~&gt; VERSION</span><span class='tstring_end'>&quot;</span></span>
 </code></pre>
 
+<h2 id="label-Limitations">Limitations</h2>
+<ul><li>
+<p>The gem doesn&#39;t support <code>patternProperties</code> yet. On GOV.UK
+we <a
+href="https://github.com/alphagov/govuk-content-schemas/blob/bdd97d18c7a9318e66f332f0748a410fddab1141/formats/frontend_links_definition.json#L67-L71">use
+this in the expanded frontend links</a>.</p>
+</li><li>
+<p>It&#39;s complicated to generate random data for <code>oneOf</code>
+properties. According to the JSON Schema spec a <code>oneOf</code> schema
+is only valid if the data is valid against <em>only one</em> of the
+clauses. To do this properly, we&#39;d have to make sure that the data
+generated below doesn&#39;t validate against the other schemas properties.</p>
+</li></ul>
+
 <h2 id="label-Usage">Usage</h2>
 
 <p><a href="https://alphagov.github.io/govuk_schemas_gem/frames.html">Read the
@@ -111,7 +125,7 @@ href="LICENSE.md">MIT License</a>.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:37 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,6 +74,20 @@ href="https://github.com/alphagov/govuk-content-schemas">govuk-content-schemas</
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_gem'>gem</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>govuk_schemas</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>~&gt; VERSION</span><span class='tstring_end'>&quot;</span></span>
 </code></pre>
 
+<h2 id="label-Limitations">Limitations</h2>
+<ul><li>
+<p>The gem doesn&#39;t support <code>patternProperties</code> yet. On GOV.UK
+we <a
+href="https://github.com/alphagov/govuk-content-schemas/blob/bdd97d18c7a9318e66f332f0748a410fddab1141/formats/frontend_links_definition.json#L67-L71">use
+this in the expanded frontend links</a>.</p>
+</li><li>
+<p>It&#39;s complicated to generate random data for <code>oneOf</code>
+properties. According to the JSON Schema spec a <code>oneOf</code> schema
+is only valid if the data is valid against <em>only one</em> of the
+clauses. To do this properly, we&#39;d have to make sure that the data
+generated below doesn&#39;t validate against the other schemas properties.</p>
+</li></ul>
+
 <h2 id="label-Usage">Usage</h2>
 
 <p><a href="https://alphagov.github.io/govuk_schemas_gem/frames.html">Read the
@@ -111,7 +125,7 @@ href="LICENSE.md">MIT License</a>.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:37 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -103,7 +103,7 @@
 </div>
 
     <div id="footer">
-  Generated on Fri Sep 23 14:26:37 2016 by
+  Generated on Thu Nov  3 17:31:15 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.3.1).
 </div>

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -23,13 +23,14 @@ module GovukSchemas
     #
     # For example:
     #
-    #     generator = GovukSchemas::RandomExample.for_schema("detailed_guide", schema_type: "frontend")
+    #     generator = GovukSchemas::RandomExample.for_schema(frontend_schema: "detailed_guide")
     #     generator.payload
     #     # => {"base_path"=>"/e42dd28e", "title"=>"dolor est...", "publishing_app"=>"elit"...}
     #
+    # @param schema_key_value [Hash]
     # @return [GovukSchemas::RandomExample]
-    def self.for_schema(schema_name, schema_type:)
-      schema = GovukSchemas::Schema.find(schema_name, schema_type: schema_type)
+    def self.for_schema(schema_key_value)
+      schema = GovukSchemas::Schema.find(schema_key_value)
       GovukSchemas::RandomExample.new(schema: schema)
     end
 

--- a/lib/govuk_schemas/schema.rb
+++ b/lib/govuk_schemas/schema.rb
@@ -3,37 +3,22 @@ module GovukSchemas
     # Find a schema by name
     #
     # @param schema [Hash] Type => Name of the schema/format:
-    # Accepted arguments:
-    # { links_schema: schema_name }
-    # { frontend_schema: schema_name }
-    # { publisher_schema: schema_name }
-    # { notification_schema: schema_name }
-    def self.find(schema)
-      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/#{type_location(schema)}"
-      JSON.parse(File.read(file_path))
-    end
-
-    # Find a schema type location by name
+    # @example
     #
-    # @param schema [Hash] Type => Name of the schema/format:
-    # Accepted arguments:
-    # { links_schema: schema_name }
-    # { frontend_schema: schema_name }
-    # { publisher_schema: schema_name }
-    # { notification_schema: schema_name }
-    def self.type_location(schema)
-      type, schema_name = schema.to_a.flatten
-      {
-        links_schema: "#{schema_name}/publisher_v2/links.json",
-        frontend_schema: "#{schema_name}/frontend/schema.json",
-        publisher_schema: "#{schema_name}/publisher_v2/schema.json",
-        notification_schema: "#{schema_name}/notification/schema.json",
-      }[type]
+    #   GovukSchemas::Schema.find(links_schema: "detailed_guide")
+    #   GovukSchemas::Schema.find(frontend_schema: "detailed_guide")
+    #   GovukSchemas::Schema.find(publisher_schema: "detailed_guide")
+    #   GovukSchemas::Schema.find(notification_schema: "detailed_guide")
+    # @return [Hash] the JSON schema as a hash
+    def self.find(schema)
+      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/#{location_for_schema_name(schema)}"
+      JSON.parse(File.read(file_path))
     end
 
     # Return all schemas in a hash, keyed by schema name
     #
     # @param schema_type [String] The type: frontend, publisher, notification or links
+    # @return [Array<Hash>] List of JSON schemas as hashes
     def self.all(schema_type: '*')
       schema_type = "publisher_v2" if schema_type == "publisher"
       Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/*/#{schema_type}/*.json").reduce({}) do |hash, file_path|
@@ -45,8 +30,22 @@ module GovukSchemas
     # Return a random schema of a certain type
     #
     # @param schema_type [String] The type: frontend, publisher, notification or links
+    # @return [Hash] a JSON schema as a hash
     def self.random_schema(schema_type:)
       all(schema_type: schema_type).values.sample
     end
+
+    # @private
+    def self.location_for_schema_name(schema)
+      type, schema_name = schema.to_a.flatten
+      {
+        links_schema: "#{schema_name}/publisher_v2/links.json",
+        frontend_schema: "#{schema_name}/frontend/schema.json",
+        publisher_schema: "#{schema_name}/publisher_v2/schema.json",
+        notification_schema: "#{schema_name}/notification/schema.json",
+      }[type]
+    end
+
+    private_class_method :location_for_schema_name
   end
 end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe GovukSchemas::RandomExample do
+  describe '.for_schema' do
+    it 'returns a random example for a schema' do
+      example = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder")
+
+      expect(example).to be_a(GovukSchemas::RandomExample)
+    end
+  end
+
   describe '#payload' do
     GovukSchemas::Schema.all.each do |file_path, schema|
       it "generates valid content for schema #{file_path}" do

--- a/spec/lib/schema_spec.rb
+++ b/spec/lib/schema_spec.rb
@@ -2,45 +2,20 @@ require 'spec_helper'
 
 RSpec.describe GovukSchemas::Schema do
   describe '.find' do
-    subject { GovukSchemas::Schema.find(type) }
-
-    context "frontend_schema" do
-      let(:type) { { frontend_schema: "detailed_guide" } }
-      it 'returns a frontend schema by name' do
-        expect(subject).to be_a(Hash)
-      end
-    end
-  end
-
-  describe '.type_location' do
-    subject { GovukSchemas::Schema.type_location(schema) }
-
-    context "frontend_schema" do
-      let(:schema) { { frontend_schema: "detailed_guide" } }
-      it 'returns the location' do
-        expect(subject).to eq('detailed_guide/frontend/schema.json')
-      end
+    it 'returns a frontend schema by name' do
+      expect(GovukSchemas::Schema.find(frontend_schema: "detailed_guide")).to be_a(Hash)
     end
 
-    context "links_schema" do
-      let(:schema) { { links_schema: "detailed_guide" } }
-      it 'returns the location' do
-        expect(subject).to eq('detailed_guide/publisher_v2/links.json')
-      end
+    it 'returns a links schema schema by name' do
+      expect(GovukSchemas::Schema.find(links_schema: "detailed_guide")).to be_a(Hash)
     end
 
-    context "publisher_schema" do
-      let(:schema) { { publisher_schema: "detailed_guide" } }
-      it 'returns the location' do
-        expect(subject).to eq('detailed_guide/publisher_v2/schema.json')
-      end
+    it 'returns a publisher schema schema by name' do
+      expect(GovukSchemas::Schema.find(publisher_schema: "detailed_guide")).to be_a(Hash)
     end
 
-    context "notification_schema" do
-      let(:schema) { { notification_schema: "detailed_guide" } }
-      it 'returns the location' do
-        expect(subject).to eq('detailed_guide/notification/schema.json')
-      end
+    it 'returns a notification schema schema by name' do
+      expect(GovukSchemas::Schema.find(notification_schema: "detailed_guide")).to be_a(Hash)
     end
   end
 


### PR DESCRIPTION
This method stopped working because we changed the signature of `Schema.find` (and we didn't have a test).

Fixes the issue by making it use the same signature as the other method.

Also adds a bunch of extra documentation and makes the new method private.
