### PR TITLE
Add functionality to work with examples

### DIFF
--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -2,6 +2,7 @@ require "govuk_schemas/version"
 require "govuk_schemas/schema"
 require "govuk_schemas/utils"
 require "govuk_schemas/random_example"
+require "govuk_schemas/example"
 
 module GovukSchemas
   # @private

--- a/lib/govuk_schemas/example.rb
+++ b/lib/govuk_schemas/example.rb
@@ -1,0 +1,25 @@
+module GovukSchemas
+  class Example
+    # Find all examples for a schema
+    #
+    # @param schema_name [String] like "detailed_guide", "policy" or "publication"
+    # @return [Array] array of example content items
+    def self.find_all(schema_name)
+      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/frontend/examples/*.json").map do |filename|
+        json = File.read(filename)
+        JSON.parse(json)
+      end
+    end
+
+    # Find an example by name
+    #
+    # @param schema_name [String] like "detailed_guide", "policy" or "publication"
+    # @param example_name [String] the name of the example JSON file
+    # @return [Hash] the example content item
+    def self.find(schema_name, example_name:)
+      path = "/formats/#{schema_name}/frontend/examples/#{example_name}.json"
+      json = File.read("#{GovukSchemas::CONTENT_SCHEMA_DIR}#{path}")
+      JSON.parse(json)
+    end
+  end
+end

--- a/spec/lib/example_spec.rb
+++ b/spec/lib/example_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe GovukSchemas::Example do
+  describe '.find_all' do
+    it "returns all the examples" do
+      examples = GovukSchemas::Example.find_all("specialist_document")
+
+      expect(examples).to be_a(Array)
+      expect(examples.size > 10).to eql(true)
+    end
+  end
+
+  describe '.find' do
+    it "returns one example" do
+      example_content_item = GovukSchemas::Example.find("specialist_document", example_name: "drug-safety-update")
+
+      expect(example_content_item).to be_a(Hash)
+    end
+  end
+end


### PR DESCRIPTION
This adds new methods to fetch the examples from govuk-content-schemas. They only include the frontend examples, because publisher examples aren't used anywhere.